### PR TITLE
Update bin2c.c to allow longer paths

### DIFF
--- a/src/tools/bin2c.c
+++ b/src/tools/bin2c.c
@@ -4,7 +4,7 @@
 
 int main(int argc, char *argv[])
 {
-    char base[100], opath[100], *name, *p;
+    char base[1024], opath[1024], *name, *p;
     FILE *ifp, *ofp;
     int byte, cnt;
 


### PR DESCRIPTION
As discussed in propgcc pull request, this fix needs to be applied here as well.
